### PR TITLE
Fix module imports for browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,15 +24,7 @@
 
   <body>
     <div id="hud">請連接 Controller 或使用鍵盤 (W/S Q/E 方向鍵)</div>
-    <!-- Three.js 與需要的 Loader -->
-    <script
-      type="module"
-      src="https://unpkg.com/three@0.151.0/build/three.module.js"
-    ></script>
-    <script
-      type="module"
-      src="https://unpkg.com/three@0.151.0/examples/jsm/loaders/GLTFLoader.js"
-    ></script>
+    <!-- Main script -->
     <script type="module" src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
-import * as THREE from 'three'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+// Import Three.js and GLTFLoader directly from the CDN
+import * as THREE from 'https://unpkg.com/three@0.151.0/build/three.module.js'
+import { GLTFLoader } from 'https://unpkg.com/three@0.151.0/examples/jsm/loaders/GLTFLoader.js'
 
 // --------------- 1. Three.js 場景、相機、渲染器 ---------------
 const scene = new THREE.Scene()


### PR DESCRIPTION
## Summary
- load three.js and GLTFLoader from the CDN directly inside the module
- clean up `index.html` to remove unused module scripts

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6840fde56058832ea6b9475cbfdaa45f